### PR TITLE
Use generic wood for crafting

### DIFF
--- a/c_doors.lua
+++ b/c_doors.lua
@@ -36,7 +36,7 @@ c_doors.door = {
 		default.node_sound_wood_defaults(), 
 		"doors_door", 
 		{name = "doors_door_wood.png", backface_culling = true}, 
-		{"default:wood", "doors:door_wood"}
+		{"group:wood", "doors:door_wood"}
 	},
 }
 

--- a/c_windows.lua
+++ b/c_windows.lua
@@ -28,7 +28,7 @@ c_doors.windowed = {
 		"Wood", 
 		"c_doors_dble_wood_sides.png", 
 		"c_doors_dble_wood.png", 
-		"default:wood"
+		"group:wood"
 	},
 }
 


### PR DESCRIPTION
This tiny patch allows crafting wood windows/doors with any kind of wood – found this very handy for example for jungles of mapgen v7.